### PR TITLE
spring-boot-rest-prometheus to 0.0.2

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -1,9 +1,12 @@
 dependencies:
-- name: exposecontroller
-  version: 2.3.58
+- alias: expose
+  name: exposecontroller
   repository: https://chartmuseum.build.cd.jenkins-x.io
-  alias: expose
-- name: exposecontroller
   version: 2.3.58
+- alias: cleanup
+  name: exposecontroller
   repository: https://chartmuseum.build.cd.jenkins-x.io
-  alias: cleanup
+  version: 2.3.58
+- name: spring-boot-rest-prometheus
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.2


### PR DESCRIPTION
Promote spring-boot-rest-prometheus to version 0.0.2